### PR TITLE
Add option to set custom environment variables

### DIFF
--- a/datadog-agent/DOCS.md
+++ b/datadog-agent/DOCS.md
@@ -19,6 +19,14 @@ This add-on is optimized for Raspberry Pi 4 and supports Raspberry Pi 3B (using 
    - Open the add-on configuration panel.
    - Enter your Datadog API key in the provided field.
    - Optionally, adjust the Datadog site (defaults to `datadoghq.com`).
+   - Optionally, set [custom environment variables for the Datadog Agent](https://docs.datadoghq.com/containers/docker/?tab=standard#environment-variables) to customize it further.
+   
+     Each entry is made up of a name and value:
+
+     - `name`: The case-sensitive environment variable name.
+     - `value`: The value to be set in the environment variable.
+
+     Note: These will also overwrite any environment variable set using the configuration options above.
 
 3.5 **(Optional)** Disable Protection Mode
    - The agent requires **Protection Mode to be disabled** for full functionality.

--- a/datadog-agent/config.yaml
+++ b/datadog-agent/config.yaml
@@ -28,11 +28,16 @@ options:
   api_key: ""
   site: "datadoghq.com"
   hostname: "my-homeassistant"
+  env_vars: []
 
 schema:
   api_key: str
   site: str?
   hostname: str
+  env_vars: [{
+      name: "str?",
+      value: "str?"
+  }]
 
 environment:
   DOCKER_SOCKET_PATH: '/run/docker.sock'

--- a/datadog-agent/run.sh
+++ b/datadog-agent/run.sh
@@ -13,4 +13,13 @@ DD_DOGSTATSD_NON_LOCAL_TRAFFIC="true" \
 DD_APM_ENABLED="false" \
 DOCKER_SOCKET_PATH="/run/docker.sock" \
 DOCKER_HOST="unix:///run/docker.sock" \
+
+# These are optional and applied last so we can override those set above if needed.
+for env_var in $(bashio::config 'env_vars|keys'); do
+    name=$(bashio::config "env_vars[${env_var}].name")
+    value=$(bashio::config "env_vars[${env_var}].value")
+    bashio::log.debug "Setting Env Variable ${name} to ${value}"
+    export "${name}=${value}"
+done
+
 exec /init


### PR DESCRIPTION
The Docker-based Datadog agent is [configured via Environment Variables](https://docs.datadoghq.com/containers/docker/?tab=standard#environment-variables) ([full list here](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml), search `@env`).

However, the current addon, while great, only supports a subset of these variables via its configuration.

It would be very useful to allow users to set arbitrary environment variables, which this PR allows.

It's based on [a common pattern across HA addons](https://github.com/search?q=for+env_var+in+%24%28bashio%3A%3Aconfig+%27env_vars%7Ckeys%27%29%3B+do&type=code), and especially [this HA Teslamate addon PR](https://github.com/lildude/ha-addon-teslamate/pull/29).

I tested it locally successfully. I was able to set `DD_CMD_PORT` to `5002` to fix [the issue](https://github.com/rapdev-io/addon-datadog-agent/issues/1) I encountered here and allow the agent to boot:
<img width="1060" height="562" alt="image" src="https://github.com/user-attachments/assets/36551da8-274a-458a-950d-9d05856d10f2" />

I hope this will be useful to you as well!